### PR TITLE
chore(security): pin actions/checkout to SHA and add CODEOWNERS for workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Workflow files run with elevated privileges via the
+# "Protect Main" ruleset bypass granted to github-actions[bot].
+# Any change here can land a commit on main without going
+# through the standard PR review — require explicit owner
+# review for these paths.
+.github/workflows/** @cmaenner
+.github/CODEOWNERS    @cmaenner

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -11,7 +11,7 @@ jobs:
   build-plugin-zip:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Build plugin zip
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Checkout
         if: steps.skip.outputs.skip != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Hardening that pairs with granting `github-actions[bot]` bypass on the **"Protect Main"** ruleset (separate config change, applied via API). Both mitigations close concrete supply-chain and review-bypass risks introduced by the bypass.

### What changes

- **Pin `actions/checkout`** to commit SHA `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1, verified-signed by GitHub, published 2025-11-17) in both release workflows (`release.yml`, `release-plugin.yml`). A future malicious release published under the `@v4` tag can no longer execute inside our release job with the bypass token.
- **Add `.github/CODEOWNERS`** requiring explicit owner review for `.github/workflows/**` and CODEOWNERS itself. Combined with `require_code_owner_review: true` on the ruleset (added via API), this gates new workflow files behind a deliberate owner review specifically because they inherit the bypass.

### Why now

The auto-bump release for `v0.2.4` failed at `git push origin HEAD:main` because the ruleset rejects unsigned, non-PR pushes (run [25755121644](https://github.com/OWASP/secure-agent-playbook/actions/runs/25755121644)). The chosen fix is to grant `github-actions[bot]` (Integration ID 15368) bypass on the ruleset. That bypass is broad — it exempts the bot from every rule, not just the two that fired — so these two mitigations narrow the realistic threat surface back down before the bypass goes live.

## Test plan

- [ ] Merge this PR (it does not require the bypass — it goes through standard review).
- [ ] After merge, apply the ruleset update (separate API call adding bypass actor + toggling `require_code_owner_review`).
- [ ] Re-run [run 25755121644](https://github.com/OWASP/secure-agent-playbook/actions/runs/25755121644) and confirm `v0.2.4` tag + release land.
- [ ] Sanity-check that a fresh PR touching `.github/workflows/**` correctly requests `@cmaenner` as code owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)