### PR TITLE
ci(release): authenticate as admin via RELEASE_PAT and add patch dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ on:
         required: true
         type: choice
         options:
+          - patch
           - minor
           - major
 
@@ -53,7 +54,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Determine bump type
         if: steps.skip.outputs.skip != 'true'
@@ -65,7 +66,7 @@ jobs:
           set -euo pipefail
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             case "$INPUT_BUMP" in
-              minor|major) BUMP="$INPUT_BUMP" ;;
+              patch|minor|major) BUMP="$INPUT_BUMP" ;;
               *) echo "Invalid bump input: $INPUT_BUMP" >&2; exit 1 ;;
             esac
           else


### PR DESCRIPTION
## Summary

Switches the release workflow's auth from the default `GITHUB_TOKEN` (which authenticates as `github-actions[bot]` — NOT a bypass actor on the "Protect Main" ruleset) to a fine-grained PAT (which authenticates as an admin user — IS already a bypass actor via `RepositoryRole=5`).

This is the same exception the failed [run 25755121644](https://github.com/OWASP/secure-agent-playbook/actions/runs/25755121644) needed, routed through existing admin privilege rather than a new integration grant. Required because the OWASP org hasn't enabled the GitHub Actions integration as a bypass-eligible actor at the org level (the `gh api PUT` to add it as a bypass actor returned `422 Validation Failed: Actor GitHub Actions integration must be part of the ruleset source or owner organization`).

Also adds `patch` to the `workflow_dispatch` input options so manual patch releases are possible — needed specifically because `.github/**` is in `paths-ignore`, so merging this workflow-only PR will NOT auto-trigger the next release. The first run after merge has to be a manual dispatch.

## Prerequisite (must do BEFORE merging this PR)

A repo secret `RELEASE_PAT` must exist. To create it:

1. Visit https://github.com/settings/personal-access-tokens/new
2. **Resource owner**: `OWASP`, **Repository access**: Only `secure-agent-playbook`
3. **Repository permissions**: `Contents: Read and write` (only this)
4. **Expiry**: 90 days
5. Add the token at https://github.com/OWASP/secure-agent-playbook/settings/secrets/actions/new as `RELEASE_PAT`

## Test plan

- [ ] `RELEASE_PAT` secret exists in repo settings
- [ ] Merge this PR
- [ ] Manually trigger: `gh workflow run release.yml --ref main --field bump=patch --repo OWASP/secure-agent-playbook`
- [ ] Run completes successfully: bumps manifests to `0.2.4`, pushes commit to main, tags `v0.2.4`, creates release
- [ ] Confirm `release-plugin.yml` runs after the release publish and attaches the zip

## Pairs with already-merged

- PR #16 (pinned `actions/checkout` to SHA + CODEOWNERS for workflow paths) — the two mitigations that paired with introducing this auth pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)