### PR TITLE
Fix stale OWASP LLM Top 10 IDs (LLM02 → LLM05 for output handling)

### DIFF
--- a/plugins/ai-security-skills/plays/agent-security-audit.md
+++ b/plugins/ai-security-skills/plays/agent-security-audit.md
@@ -111,7 +111,8 @@ Check for presence and effectiveness of:
 ## OWASP References
 
 - **LLM01**: Prompt Injection
-- **LLM02**: Insecure Output Handling
+- **LLM02**: Sensitive Information Disclosure
+- **LLM05**: Improper Output Handling
 - **LLM06**: Excessive Agency
 - **LLM07**: System Prompt Leakage
 - **LLM08**: Vector and Embedding Weaknesses (for RAG agents)

--- a/plugins/ai-security-skills/plays/mcp-server-review.md
+++ b/plugins/ai-security-skills/plays/mcp-server-review.md
@@ -123,7 +123,8 @@ Check the client-side MCP configuration:
 ## OWASP References
 
 - **LLM01**: Prompt Injection (via tool descriptions and outputs)
-- **LLM02**: Insecure Output Handling (tool output rendering)
+- **LLM02**: Sensitive Information Disclosure (secrets/PII in resources and tool outputs)
+- **LLM05**: Improper Output Handling (tool output rendering)
 - **LLM06**: Excessive Agency (overpermissioned tools)
 - **LLM07**: System Prompt Leakage (sensitive data in tool descriptions)
 - OWASP Top 10: A01 Broken Access Control, A03 Injection

--- a/plugins/ai-security-skills/plays/prompt-injection-testing.md
+++ b/plugins/ai-security-skills/plays/prompt-injection-testing.md
@@ -337,7 +337,7 @@ When testing programmatically, consider:
 ## OWASP References
 
 - **LLM01**: Prompt Injection — this play's primary focus
-- **LLM02**: Insecure Output Handling — test whether injected prompts produce dangerous outputs
+- **LLM05**: Improper Output Handling — test whether injected prompts produce dangerous outputs
 - **LLM06**: Excessive Agency — test whether injection can trigger unauthorized tool calls
 - **LLM07**: System Prompt Leakage — INT-01 and INT-05 directly test this
 - OWASP AI Exchange: Prompt Injection Controls

--- a/plugins/ai-security-skills/skills/agent-security-audit/SKILL.md
+++ b/plugins/ai-security-skills/skills/agent-security-audit/SKILL.md
@@ -29,7 +29,8 @@ Use the finding format from `templates/finding.md`. Produce a Permission Summary
 ## OWASP References
 
 - LLM01: Prompt Injection
-- LLM02: Insecure Output Handling
+- LLM02: Sensitive Information Disclosure
+- LLM05: Improper Output Handling
 - LLM06: Excessive Agency
 - LLM07: System Prompt Leakage
 - LLM08: Vector and Embedding Weaknesses

--- a/plugins/ai-security-skills/skills/mcp-server-review/SKILL.md
+++ b/plugins/ai-security-skills/skills/mcp-server-review/SKILL.md
@@ -31,7 +31,8 @@ Server overview, tool risk matrix, findings using `templates/finding.md`, and sp
 ## OWASP References
 
 - LLM01: Prompt Injection (via tool descriptions and outputs)
-- LLM02: Insecure Output Handling
+- LLM02: Sensitive Information Disclosure
+- LLM05: Improper Output Handling
 - LLM06: Excessive Agency (overpermissioned tools)
 - A01: Broken Access Control
 - A03: Injection

--- a/plugins/ai-security-skills/skills/prompt-injection-test/SKILL.md
+++ b/plugins/ai-security-skills/skills/prompt-injection-test/SKILL.md
@@ -47,6 +47,6 @@ Test results summary table (intent / technique / evasion / surface / result / se
 ## OWASP References
 
 - LLM01: Prompt Injection
-- LLM02: Insecure Output Handling
+- LLM05: Improper Output Handling
 - LLM06: Excessive Agency
 - LLM07: System Prompt Leakage


### PR DESCRIPTION
## Summary
- Align AI security skills/plays with OWASP LLM Top 10 2025 naming
- Map improper/insecure output handling to **LLM05**, not LLM02
- Use **LLM02** only for Sensitive Information Disclosure where data-exposure concerns apply

Fixes #25 

## Changes
Updated OWASP reference sections in:
- `plugins/ai-security-skills/skills/mcp-server-review/SKILL.md`
- `plugins/ai-security-skills/skills/agent-security-audit/SKILL.md`
- `plugins/ai-security-skills/skills/prompt-injection-test/SKILL.md`
- `plugins/ai-security-skills/plays/mcp-server-review.md`
- `plugins/ai-security-skills/plays/agent-security-audit.md`
- `plugins/ai-security-skills/plays/prompt-injection-testing.md`

Aligned with `llm-risk-assess` and `data/llm-top10/`.

## Testing
- [x] Confirm no remaining "Insecure Output Handling" strings in the repo
- [x] Spot-check each updated OWASP References section against LLM02/LLM05 in `data/llm-top10/`