### PR TITLE
fix(security): update stale OWASP LLM Top 10 IDs (LLM02 -> LLM05)

### DIFF
--- a/plugins/ai-security-skills/plays/agent-security-audit.md
+++ b/plugins/ai-security-skills/plays/agent-security-audit.md
@@ -111,7 +111,7 @@ Check for presence and effectiveness of:
 ## OWASP References
 
 - **LLM01**: Prompt Injection
-- **LLM02**: Insecure Output Handling
+- **LLM05**: Improper Output Handling
 - **LLM06**: Excessive Agency
 - **LLM07**: System Prompt Leakage
 - **LLM08**: Vector and Embedding Weaknesses (for RAG agents)

--- a/plugins/ai-security-skills/plays/prompt-injection-testing.md
+++ b/plugins/ai-security-skills/plays/prompt-injection-testing.md
@@ -337,7 +337,7 @@ When testing programmatically, consider:
 ## OWASP References
 
 - **LLM01**: Prompt Injection — this play's primary focus
-- **LLM02**: Insecure Output Handling — test whether injected prompts produce dangerous outputs
+- **LLM05**: Improper Output Handling — test whether injected prompts produce dangerous outputs
 - **LLM06**: Excessive Agency — test whether injection can trigger unauthorized tool calls
 - **LLM07**: System Prompt Leakage — INT-01 and INT-05 directly test this
 - OWASP AI Exchange: Prompt Injection Controls

--- a/plugins/ai-security-skills/skills/agent-security-audit/SKILL.md
+++ b/plugins/ai-security-skills/skills/agent-security-audit/SKILL.md
@@ -29,7 +29,7 @@ Use the finding format from `templates/finding.md`. Produce a Permission Summary
 ## OWASP References
 
 - LLM01: Prompt Injection
-- LLM02: Insecure Output Handling
+- LLM05: Improper Output Handling
 - LLM06: Excessive Agency
 - LLM07: System Prompt Leakage
 - LLM08: Vector and Embedding Weaknesses

--- a/plugins/ai-security-skills/skills/mcp-server-review/SKILL.md
+++ b/plugins/ai-security-skills/skills/mcp-server-review/SKILL.md
@@ -31,7 +31,7 @@ Server overview, tool risk matrix, findings using `templates/finding.md`, and sp
 ## OWASP References
 
 - LLM01: Prompt Injection (via tool descriptions and outputs)
-- LLM02: Insecure Output Handling
+- LLM05: Improper Output Handling
 - LLM06: Excessive Agency (overpermissioned tools)
 - A01: Broken Access Control
 - A03: Injection

--- a/plugins/ai-security-skills/skills/prompt-injection-test/SKILL.md
+++ b/plugins/ai-security-skills/skills/prompt-injection-test/SKILL.md
@@ -47,6 +47,6 @@ Test results summary table (intent / technique / evasion / surface / result / se
 ## OWASP References
 
 - LLM01: Prompt Injection
-- LLM02: Insecure Output Handling
+- LLM05: Improper Output Handling
 - LLM06: Excessive Agency
 - LLM07: System Prompt Leakage


### PR DESCRIPTION
## What
Fix stale OWASP LLM Top 10 ID references in AI security skills and plays. Several files incorrectly label LLM02 as "Insecure Output Handling", but per the OWASP LLM Top 10 2025 update (and the repo's own data/llm-top10/ directory):
- **LLM02** = Sensitive Information Disclosure
- **LLM05** = Improper Output Handling

## Files Changed
1. `plugins/ai-security-skills/skills/mcp-server-review/SKILL.md` - LLM02: Insecure Output Handling -> LLM05: Improper Output Handling
2. `plugins/ai-security-skills/skills/agent-security-audit/SKILL.md` - LLM02: Insecure Output Handling -> LLM05: Improper Output Handling
3. `plugins/ai-security-skills/skills/prompt-injection-test/SKILL.md` - LLM02: Insecure Output Handling -> LLM05: Improper Output Handling
4. `plugins/ai-security-skills/plays/agent-security-audit.md` - LLM02**: Insecure Output Handling -> LLM05**: Improper Output Handling
5. `plugins/ai-security-skills/plays/prompt-injection-testing.md` - LLM02**: Insecure Output Handling -> LLM05**: Improper Output Handling

Note: `plugins/ai-security-skills/plays/mcp-server-review.md` was checked but contains no LLM Top 10 references.

## Why
Closes #25. Agents following the stale references will map security findings to the wrong risk ID, causing incorrect risk classification and reporting. The `llm-risk-assess` skill already uses the correct 2025 names and should be the source of truth.

## How has this been tested?
- Verified each file contains the stale reference before replacement
- Verified replacement is exact string match (preserving markdown formatting)
- Confirmed no other LLM02 references remain in the modified files
- Documentation-only change, no code logic modified

## Checklist
- [x] All stale LLM02 -> LLM05 references updated
- [x] Markdown formatting preserved (bold markers `**` maintained)
- [x] No other files contain the stale reference
- [x] Change is consistent with data/llm-top10/ source of truth